### PR TITLE
Interpret "Invalid" tests (in particular for ASN1)

### DIFF
--- a/fiat_p256.opam
+++ b/fiat_p256.opam
@@ -15,6 +15,7 @@ build: [
 ]
 depends: [
   "alcotest" {with-test}
+  "asn1-combinators" {with-test}
   "cstruct" {>= "3.5.0"}
   "dune" {build & >= "1.6.0"}
   "hex"

--- a/test_wycheproof/dune
+++ b/test_wycheproof/dune
@@ -1,5 +1,5 @@
 (test
  (name test)
  (deps ecdh_secp256r1_test.json)
- (libraries alcotest fiat_p256 wycheproof str)
+ (libraries alcotest fiat_p256 wycheproof str asn1-combinators)
 )

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -2,28 +2,28 @@ open Wycheproof
 
 let hex = Alcotest.testable Wycheproof.pp_hex Wycheproof.equal_hex
 
-let strip_prefix s ~prefix =
-  let prefix_len = String.length prefix in
-  let s_len = String.length s in
-  if prefix_len > s_len then None
-  else
-    let prefix_in_s = String.sub s 0 prefix_len in
-    if String.equal prefix prefix_in_s then
-      Some (Str.string_after s prefix_len)
-    else None
-
 let result_of_option ~msg = function
   | None ->
       Error msg
   | Some x ->
       Ok x
 
-let strip_asn1 s =
-  let prefix =
-    Hex.to_string
-      (`Hex "3059301306072a8648ce3d020106082a8648ce3d030107034200")
-  in
-  result_of_option ~msg:"unknown ASN1 prefix" (strip_prefix ~prefix s)
+let parse_asn1 s =
+  let cs = Cstruct.of_string s in
+  let seq2 a b = Asn.S.(sequence2 (required a) (required b)) in
+  let term = Asn.S.(seq2 (seq2 oid oid) bit_string_cs) in
+  let ec_public_key = Asn.OID.(base 1 2 <|| [840; 10045; 2; 1]) in
+  let prime256v1 = Asn.OID.(base 1 2 <|| [840; 10045; 3; 1; 7]) in
+  match Asn.decode (Asn.codec Asn.ber term) cs with
+  | Error _ ->
+      Error "ASN1 parse error"
+  | Ok (((oid1, oid2), data), rest) ->
+      if Cstruct.len rest <> 0 then Error "ASN1 leftover"
+      else if not (Asn.OID.equal oid1 ec_public_key) then
+        Error "ASN1: wrong oid 1"
+      else if not (Asn.OID.equal oid2 prime256v1) then
+        Error "ASN1: wrong oid 2"
+      else Ok (Cstruct.to_string data)
 
 let ( >>= ) xr f =
   match xr with
@@ -33,7 +33,7 @@ let ( >>= ) xr f =
       f x
 
 let parse_point s =
-  strip_asn1 s
+  parse_asn1 s
   >>= fun payload ->
   result_of_option ~msg:"cannot parse point"
     (Fiat_p256.point_of_hex (Hex.of_string payload))
@@ -55,27 +55,54 @@ let interpret_test {name; point; scalar; expected} =
   in
   (name, `Quick, run)
 
+type invalid_test =
+  { name : string
+  ; public : string
+  ; private_ : string }
+
+let is_ok = function
+  | Ok _ ->
+      true
+  | Error _ ->
+      false
+
+let interpret_invalid_test {name; public; private_} =
+  let run () =
+    let result =
+      parse_point public >>= fun _ -> parse_scalar private_ >>= fun _ -> Ok ()
+    in
+    Alcotest.check Alcotest.bool __LOC__ false (is_ok result)
+  in
+  (name, `Quick, run)
+
 type strategy =
   | Test of test
+  | Invalid_test of invalid_test
   | Skip
 
 let test_name test = Printf.sprintf "%d - %s" test.tcId test.comment
 
 let make_test test =
-  let ignored_flags = ["InvalidAsn"; "CompressedPoint"; "UnnamedCurve"] in
+  let ignored_flags = ["CompressedPoint"; "UnnamedCurve"] in
+  let name = test_name test in
   match test.result with
   | _
     when has_ignored_flag test ~ignored_flags ->
       Ok Skip
-  | Invalid ->
+  | _
+    when test.comment = "point is not on curve"
+         || List.mem test.tcId [92; 93; 94] ->
+      (* Disable tests with invalid points - see #3 *)
       Ok Skip
-  | Valid
-   |Acceptable ->
+  | Invalid ->
+      Ok (Invalid_test {name; public = test.public; private_ = test.private_})
+  | Acceptable ->
+      Ok Skip
+  | Valid ->
       parse_point test.public
       >>= fun point ->
       parse_scalar test.private_
       >>= fun scalar ->
-      let name = test_name test in
       Ok (Test {name; point; scalar; expected = test.shared})
 
 let concat_map f l = List.map f l |> List.concat
@@ -84,10 +111,12 @@ let to_tests x =
   match make_test x with
   | Ok (Test t) ->
       [interpret_test t]
+  | Ok (Invalid_test t) ->
+      [interpret_invalid_test t]
   | Ok Skip ->
       []
   | Error e ->
-      failwith e
+      Printf.ksprintf failwith "While parsing %d: %s" x.tcId e
 
 let tests =
   let data = load_file_exn "ecdh_secp256r1_test.json" in


### PR DESCRIPTION
This makes sure that test cases marked "invalid" are indeed rejected. Parsing ASN1 by stripping the prefix is a bit brittle, so instead this adds asn1-combinators as a test dependency.

Since this library does not deal with ASN1 encoding itself, the ASN1 tests do not have a lot of value, but it also comes for tests cases for invalid points, etc.