### PR TITLE
Check point at infinity

### DIFF
--- a/p256/error.ml
+++ b/p256/error.ml
@@ -1,0 +1,28 @@
+type point_error =
+  [ `InvalidFormat
+  | `InvalidLength
+  | `InvalidRange
+  | `NotOnCurve
+  | `AtInfinity ]
+
+type scalar_error =
+  [ `InvalidLength
+  | `InvalidRange ]
+
+let error_to_string = function
+  | `InvalidFormat ->
+      "invalid format"
+  | `NotOnCurve ->
+      "point is not on curve"
+  | `AtInfinity ->
+      "point is at infinity"
+  | `InvalidLength ->
+      "invalid length"
+  | `InvalidRange ->
+      "invalid range"
+
+let pp_point_error fmt e =
+  Format.fprintf fmt "Cannot parse point: %s" (error_to_string e)
+
+let pp_scalar_error fmt e =
+  Format.fprintf fmt "Cannot parse scalar: %s" (error_to_string e)

--- a/p256/error.mli
+++ b/p256/error.mli
@@ -1,0 +1,14 @@
+type point_error =
+  [ `InvalidFormat
+  | `InvalidRange
+  | `InvalidLength
+  | `NotOnCurve
+  | `AtInfinity ]
+
+type scalar_error =
+  [ `InvalidLength
+  | `InvalidRange ]
+
+val pp_point_error : Format.formatter -> point_error -> unit
+
+val pp_scalar_error : Format.formatter -> scalar_error -> unit

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -36,21 +36,31 @@ let%expect_test "dh" =
 
 type point = Point.t
 
-type point_error = Point.error
+type point_error = Error.point_error
 
-let pp_point_error = Point.pp_error
+let pp_point_error = Error.pp_point_error
 
-let point_of_hex = Point.of_hex
+let check_point = function
+  | Ok p
+    when not (Point.is_infinity p) ->
+      Ok p
+  | Ok _ ->
+      Error `AtInfinity
+  | Error _ as e ->
+      e
 
-let point_of_cs = Point.of_cstruct
+let point_of_hex h =
+  check_point (Point.of_hex h)
+
+let point_of_cs c = check_point (Point.of_cstruct c)
 
 let point_to_cs = Point.to_cstruct
 
 type scalar = Scalar.t
 
-type scalar_error = Scalar.error
+type scalar_error = Error.scalar_error
 
-let pp_scalar_error = Scalar.pp_error
+let pp_scalar_error = Error.pp_scalar_error
 
 let scalar_of_hex = Scalar.of_hex
 

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -1,18 +1,20 @@
-(** A point on the P-256 curve (public key). *)
+(** A point on the P-256 curve (public key), that is not the point at infinity. *)
 type point
 
 (** The type for point parsing errors. *)
 type point_error =
-  [ `CoordinateTooLarge
+  [ `InvalidRange
   | `InvalidFormat
   | `InvalidLength
-  | `NotOnCurve ]
+  | `NotOnCurve
+  | `AtInfinity ]
 
 val pp_point_error : Format.formatter -> point_error -> unit
 (** Pretty printer for point parsing errors *)
 
 val point_of_cs : Cstruct.t -> (point, point_error) result
-(** Convert from cstruct. The format is the uncompressed format described in
+(** Convert from cstruct. Refuses the point at infinity.
+    The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
 
     - the point at infinity is the single byte "00".
@@ -43,7 +45,8 @@ val pp_scalar_error : Format.formatter -> scalar_error -> unit
 
 val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
 (** Read data from a cstruct.
-    It should be 32 bytes long, in big endian format. *)
+    It should be 32 bytes long, in big endian format. Returns an error when the
+    number is zero, or if it is larger than or equal to the group order. *)
 
 val scalar_of_hex : Hex.t -> (scalar, scalar_error) result
 (** Like [scalar_of_cs] but read from hex data. *)
@@ -54,4 +57,5 @@ val dh : scalar:scalar -> point:point -> Cstruct.t
 
 val public : scalar -> point
 (** Compute the public key corresponding to a given private key. Internally,
-    this multiplies the generator by the scalar. *)
+    this multiplies the generator by the scalar.
+    Given the invariant on [scalar], the result can't be the point at infinity. *)

--- a/p256/point.ml
+++ b/p256/point.ml
@@ -135,8 +135,8 @@ let of_hex_exn h =
   match of_hex h with
   | Ok p ->
       p
-  | Error _ ->
-      failwith "of_hex_exn"
+  | Error e ->
+      failwith (Format.asprintf "of_hex_exn: %a" Error.pp_point_error e)
 
 let to_affine p =
   if is_infinity p then None

--- a/p256/point.ml
+++ b/p256/point.ml
@@ -3,30 +3,13 @@ type t =
   ; f_y : Fe.t
   ; f_z : Fe.t }
 
-type error =
-  [ `CoordinateTooLarge
-  | `InvalidFormat
-  | `InvalidLength
-  | `NotOnCurve ]
-
-let error_to_string = function
-  | `CoordinateTooLarge ->
-      "coordinate out of range"
-  | `InvalidFormat ->
-      "invalid format"
-  | `InvalidLength ->
-      "invalid length"
-  | `NotOnCurve ->
-      "point is not on curve"
-
-let pp_error fmt e =
-  Format.fprintf fmt "Cannot parse point: %s" (error_to_string e)
-
 let at_infinity () =
   let f_x = Fe.one () in
   let f_y = Fe.one () in
   let f_z = Fe.create () in
   {f_x; f_y; f_z}
+
+let is_infinity p = not (Fe.nz p.f_z)
 
 let is_solution_to_curve_equation ~x ~y =
   let a = Fe.from_be_cstruct (Hex.to_cstruct Parameters.a) in
@@ -62,7 +45,7 @@ let validate_finite_point ~x ~y =
         Ok {f_x; f_y; f_z}
       else Error `NotOnCurve
   | _ ->
-      Error `CoordinateTooLarge
+      Error `InvalidRange
 
 let%expect_test "validate_finite_point" =
   let is_ok = function
@@ -156,8 +139,7 @@ let of_hex_exn h =
       failwith "of_hex_exn"
 
 let to_affine p =
-  let is_infty = not (Fe.nz p.f_z) in
-  if is_infty then None
+  if is_infinity p then None
   else
     let out_x = Cstruct.create 32 in
     let out_y = Cstruct.create 32 in

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -13,7 +13,11 @@ val add : t -> t -> t
 val double : t -> t
 (** Point doubling. [double p] returns the result of doubling [p]. *)
 
-val of_cstruct : Cstruct.t -> (t, Error.point_error) result
+val of_cstruct :
+     Cstruct.t
+  -> ( t
+     , [> `InvalidFormat | `InvalidLength | `InvalidRange | `NotOnCurve] )
+     result
 (** Convert from cstruct. The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
 
@@ -26,7 +30,11 @@ val of_cstruct : Cstruct.t -> (t, Error.point_error) result
     @see <http://www.secg.org/sec1-v2.pdf>
 *)
 
-val of_hex : Hex.t -> (t, Error.point_error) result
+val of_hex :
+     Hex.t
+  -> ( t
+     , [> `InvalidFormat | `InvalidLength | `InvalidRange | `NotOnCurve] )
+     result
 (** Convert from hex. See [of_cstruct]. *)
 
 val of_hex_exn : Hex.t -> t

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -1,16 +1,11 @@
 (** A Point on the P-256 curve. *)
 type t
 
-type error =
-  [ `CoordinateTooLarge
-  | `InvalidFormat
-  | `InvalidLength
-  | `NotOnCurve ]
-
-val pp_error : Format.formatter -> error -> unit
-
 val at_infinity : unit -> t
 (** The point at infinity *)
+
+val is_infinity : t -> bool
+(** [is_infty p] checks wether [p] is the point at infinity. *)
 
 val add : t -> t -> t
 (** Point addition. [add p q] returns the result of the addition of [p] and [q]. *)
@@ -18,7 +13,7 @@ val add : t -> t -> t
 val double : t -> t
 (** Point doubling. [double p] returns the result of doubling [p]. *)
 
-val of_cstruct : Cstruct.t -> (t, error) result
+val of_cstruct : Cstruct.t -> (t, Error.point_error) result
 (** Convert from cstruct. The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
 
@@ -31,7 +26,7 @@ val of_cstruct : Cstruct.t -> (t, error) result
     @see <http://www.secg.org/sec1-v2.pdf>
 *)
 
-val of_hex : Hex.t -> (t, error) result
+val of_hex : Hex.t -> (t, Error.point_error) result
 (** Convert from hex. See [of_cstruct]. *)
 
 val of_hex_exn : Hex.t -> t

--- a/p256/scalar.ml
+++ b/p256/scalar.ml
@@ -1,18 +1,5 @@
 type t = Scalar of Cstruct.t
 
-type error =
-  [ `InvalidLength
-  | `InvalidRange ]
-
-let error_to_string = function
-  | `InvalidLength ->
-      "input has incorrect length"
-  | `InvalidRange ->
-      "input is not in [1; n-1]"
-
-let pp_error fmt e =
-  Format.fprintf fmt "Cannot parse scalar: %s" (error_to_string e)
-
 let pp fmt (Scalar s) = Cstruct_util.pp_hex_le fmt s
 
 let is_in_range cs =
@@ -31,7 +18,7 @@ let of_hex h =
 
 let pp_err pp fmt = function
   | Error e ->
-      pp_error fmt e
+      Error.pp_scalar_error fmt e
   | Ok x ->
       pp fmt x
 
@@ -51,10 +38,10 @@ let%expect_test "of_hex" =
   test
     (`Hex
       "2000000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
-  [%expect {| Cannot parse scalar: input has incorrect length |}];
+  [%expect {| Cannot parse scalar: invalid length |}];
   test
     (`Hex "0000000000000000000000000000000000000000000000000000000000000000");
-  [%expect {| Cannot parse scalar: input is not in [1; n-1] |}];
+  [%expect {| Cannot parse scalar: invalid range |}];
   test
     (`Hex
       (* n-1 *)
@@ -62,19 +49,19 @@ let%expect_test "of_hex" =
   [%expect
     {| ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550 |}];
   test Parameters.n;
-  [%expect {| Cannot parse scalar: input is not in [1; n-1] |}];
+  [%expect {| Cannot parse scalar: invalid range |}];
   test
     (`Hex
       (* n+1 *)
       "FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632552");
-  [%expect {| Cannot parse scalar: input is not in [1; n-1] |}]
+  [%expect {| Cannot parse scalar: invalid range |}]
 
 let of_hex_exn h =
   match of_hex h with
   | Ok p ->
       p
   | Error e ->
-      Printf.ksprintf failwith "of_hex_exn: %s" (error_to_string e)
+      failwith (Format.asprintf "of_hex_exn: %a" Error.pp_scalar_error e)
 
 let bit_at (Scalar s) i =
   let byte_num = i / 8 in

--- a/p256/scalar.mli
+++ b/p256/scalar.mli
@@ -1,18 +1,12 @@
 (** A scalar value strictly between 1 and n-1 where n is the group order. *)
 type t
 
-type error =
-  [ `InvalidLength
-  | `InvalidRange ]
-
-val pp_error : Format.formatter -> error -> unit
-
-val of_cstruct : Cstruct.t -> (t, error) result
+val of_cstruct : Cstruct.t -> (t, Error.scalar_error) result
 (** Read data from a cstruct.
     It should be 32 bytes long, in big endian format. Returns an error when the
     number is zero, or if it is larger than or equal to the group order. *)
 
-val of_hex : Hex.t -> (t, error) result
+val of_hex : Hex.t -> (t, Error.scalar_error) result
 (** Like [of_cstruct] but read from hex data. *)
 
 val of_hex_exn : Hex.t -> t


### PR DESCRIPTION
Fixes #3 by checking that points are not at infinity.

- Given the invariant on the scalar points, it seems impossible to construct a `scalar` such that `public scalar` is the point at infinity.
- Therefore, the only verification to be done are for `point_of_cs` and `point_of_hex`.
- We chose to do this verification in `fiat_` instead of `Point`, so that the point module remains independent of this check, and `of_hex` and `of_cstruct` can be used elsewhere internally if needed.