### PR TITLE
Use results instead of options

### DIFF
--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -38,6 +38,8 @@ type point = Point.t
 
 type point_error = Point.error
 
+let pp_point_error = Point.pp_error
+
 let point_of_hex = Point.of_hex
 
 let point_of_cs = Point.of_cstruct
@@ -47,6 +49,8 @@ let point_to_cs = Point.to_cstruct
 type scalar = Scalar.t
 
 type scalar_error = Scalar.error
+
+let pp_scalar_error = Scalar.pp_error
 
 let scalar_of_hex = Scalar.of_hex
 

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -46,6 +46,8 @@ let point_to_cs = Point.to_cstruct
 
 type scalar = Scalar.t
 
+type scalar_error = Scalar.error
+
 let scalar_of_hex = Scalar.of_hex
 
 let scalar_of_cs = Scalar.of_cstruct

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -36,6 +36,8 @@ let%expect_test "dh" =
 
 type point = Point.t
 
+type point_error = Point.error
+
 let point_of_hex = Point.of_hex
 
 let point_of_cs = Point.of_cstruct

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -1,6 +1,7 @@
 (** A point on the P-256 curve (public key). *)
 type point
 
+(** The type for point parsing errors. *)
 type point_error = [
   `CoordinateTooLarge
   | `InvalidFormat
@@ -30,6 +31,7 @@ val point_to_cs : point -> Cstruct.t
 (** A scalar value. *)
 type scalar
 
+(** The type for scalar parsing errors. *)
 type scalar_error = [
   `InvalidLength
   | `InvalidRange

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -1,7 +1,14 @@
 (** A point on the P-256 curve (public key). *)
 type point
 
-val point_of_cs : Cstruct.t -> point option
+type point_error = [
+  `CoordinateTooLarge
+  | `InvalidFormat
+  | `InvalidLength
+  | `NotOnCurve
+]
+
+val point_of_cs : Cstruct.t -> (point, point_error) result
 (** Convert from cstruct. The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
 
@@ -14,7 +21,7 @@ val point_of_cs : Cstruct.t -> point option
     @see <http://www.secg.org/sec1-v2.pdf>
 *)
 
-val point_of_hex : Hex.t -> point option
+val point_of_hex : Hex.t -> (point, point_error) result
 (** Convert a point from hex. See [point_of_cs]. *)
 
 val point_to_cs : point -> Cstruct.t

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -2,12 +2,14 @@
 type point
 
 (** The type for point parsing errors. *)
-type point_error = [
-  `CoordinateTooLarge
+type point_error =
+  [ `CoordinateTooLarge
   | `InvalidFormat
   | `InvalidLength
-  | `NotOnCurve
-]
+  | `NotOnCurve ]
+
+val pp_point_error : Format.formatter -> point_error -> unit
+(** Pretty printer for point parsing errors *)
 
 val point_of_cs : Cstruct.t -> (point, point_error) result
 (** Convert from cstruct. The format is the uncompressed format described in
@@ -32,10 +34,12 @@ val point_to_cs : point -> Cstruct.t
 type scalar
 
 (** The type for scalar parsing errors. *)
-type scalar_error = [
-  `InvalidLength
-  | `InvalidRange
-]
+type scalar_error =
+  [ `InvalidLength
+  | `InvalidRange ]
+
+val pp_scalar_error : Format.formatter -> scalar_error -> unit
+(** Pretty printer for scalar parsing errors *)
 
 val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
 (** Read data from a cstruct.

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -30,11 +30,16 @@ val point_to_cs : point -> Cstruct.t
 (** A scalar value. *)
 type scalar
 
-val scalar_of_cs : Cstruct.t -> (scalar, string) result
+type scalar_error = [
+  `InvalidLength
+  | `InvalidRange
+]
+
+val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
 (** Read data from a cstruct.
     It should be 32 bytes long, in big endian format. *)
 
-val scalar_of_hex : Hex.t -> (scalar, string) result
+val scalar_of_hex : Hex.t -> (scalar, scalar_error) result
 (** Like [scalar_of_cs] but read from hex data. *)
 
 val dh : scalar:scalar -> point:point -> Cstruct.t

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -2,12 +2,13 @@
     It is backed by [Fe.t], and as such, is mutable. *)
 type t
 
-type error = [
-  `CoordinateTooLarge
+type error =
+  [ `CoordinateTooLarge
   | `InvalidFormat
   | `InvalidLength
-  | `NotOnCurve
-]
+  | `NotOnCurve ]
+
+val pp_error : Format.formatter -> error -> unit
 
 val at_infinity : unit -> t
 (** The point at infinity *)

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -2,6 +2,13 @@
     It is backed by [Fe.t], and as such, is mutable. *)
 type t
 
+type error = [
+  `CoordinateTooLarge
+  | `InvalidFormat
+  | `InvalidLength
+  | `NotOnCurve
+]
+
 val at_infinity : unit -> t
 (** The point at infinity *)
 
@@ -13,7 +20,7 @@ val double : t -> t
 (** Point doubling. [double dst p q] doubles [p], and stores the result
     into [dst]. *)
 
-val of_cstruct : Cstruct.t -> t option
+val of_cstruct : Cstruct.t -> (t, error) result
 (** Convert from cstruct. The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
 
@@ -26,7 +33,7 @@ val of_cstruct : Cstruct.t -> t option
     @see <http://www.secg.org/sec1-v2.pdf>
 *)
 
-val of_hex : Hex.t -> t option
+val of_hex : Hex.t -> (t, error) result
 (** Convert from hex. See [of_cstruct]. *)
 
 val of_hex_exn : Hex.t -> t

--- a/p256/scalar.mli
+++ b/p256/scalar.mli
@@ -1,12 +1,17 @@
 (** A scalar value strictly between 1 and n-1 where n is the group order. *)
 type t
 
-val of_cstruct : Cstruct.t -> (t, string) result
+type error = [
+  `InvalidLength
+  | `InvalidRange
+]
+
+val of_cstruct : Cstruct.t -> (t, error) result
 (** Read data from a cstruct.
     It should be 32 bytes long, in big endian format. Returns an error when the
     number is zero, or if it is larger than or equal to the group order. *)
 
-val of_hex : Hex.t -> (t, string) result
+val of_hex : Hex.t -> (t, error) result
 (** Like [of_cstruct] but read from hex data. *)
 
 val of_hex_exn : Hex.t -> t

--- a/p256/scalar.mli
+++ b/p256/scalar.mli
@@ -1,10 +1,11 @@
 (** A scalar value strictly between 1 and n-1 where n is the group order. *)
 type t
 
-type error = [
-  `InvalidLength
-  | `InvalidRange
-]
+type error =
+  [ `InvalidLength
+  | `InvalidRange ]
+
+val pp_error : Format.formatter -> error -> unit
 
 val of_cstruct : Cstruct.t -> (t, error) result
 (** Read data from a cstruct.

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -32,6 +32,10 @@ let point_error_to_string = function
   | `InvalidLength -> "invalid length"
   | `NotOnCurve -> "point is not on curve"
 
+let scalar_error_to_string = function
+  | `InvalidLength -> "input has incorrect length"
+  | `InvalidRange -> "input is not in [1; n-1]"
+
 let to_string_result ~prefix ~err_to_str = function
   | Ok _ as ok -> ok
   | Error e -> 
@@ -75,7 +79,11 @@ let pad ~total_len cs =
 let parse_scalar s =
   let stripped = strip_leading_zeroes (Cstruct.of_string s) in
   pad ~total_len:32 (Cstruct.rev stripped)
-  >>= fun cs -> Fiat_p256.scalar_of_cs (Cstruct.rev cs)
+  >>= fun cs -> 
+    to_string_result
+    ~prefix:"cannot parse scalar"
+    ~err_to_str:scalar_error_to_string
+    (Fiat_p256.scalar_of_cs (Cstruct.rev cs))
 
 type test =
   { point : Fiat_p256.point


### PR DESCRIPTION
The goal of this PR is to use a uniform interface for point/scalar parsing errors.
- Use a `result` instead of an `option` for point parsing.
- Change scalar result to use a variant instead of strings for errors.
I'm not sure whether we prefer string or variant errors though, so let's discuss that !