### PR TITLE
Fix check-vendors intermediate rules

### DIFF
--- a/p256/dune
+++ b/p256/dune
@@ -8,17 +8,17 @@
 )
 
 (rule
-  (targets upstream_p256_32.h)
+  (targets upstream_p256_32)
   (action (bash "wget https://raw.githubusercontent.com/mit-plv/fiat-crypto/ecdfd03c636ab63e167fbe4fc4d7ab0ed5d9db74/p256_32.c -O %{targets}")))
 
 (rule
-  (targets upstream_p256_64.h)
+  (targets upstream_p256_64)
   (action (bash "wget https://raw.githubusercontent.com/mit-plv/fiat-crypto/ecdfd03c636ab63e167fbe4fc4d7ab0ed5d9db74/p256_64.c -O %{targets}")))
 
 (alias 
   (name check_vendors)
-  (action (diff p256_32.h upstream_p256_32.h)))
+  (action (diff p256_32.h upstream_p256_32)))
 
 (alias 
   (name check_vendors)
-  (action (diff p256_64.h upstream_p256_64.h)))
+  (action (diff p256_64.h upstream_p256_64)))


### PR DESCRIPTION
Dune seems to get confused and runs the rules for `upstream_p256_*.h`
when running `dune build`. For some reason dune feels like it needs
those `.h` files. I'm guessing it has no way to tell which `.h` files it
need in advance so I'm not sure we should report this upstream.

In the meantime I renamed the targets to remove the `.h` extension and
it fixes the issue.