### PR TITLE
Improve API documentation

### DIFF
--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -15,15 +15,13 @@ val pp_point_error : Format.formatter -> point_error -> unit
 val point_of_cs : Cstruct.t -> (point, point_error) result
 (** Convert from cstruct. Refuses the point at infinity.
     The format is the uncompressed format described in
-    SEC1, section 2.3.4, that is to say:
+    {{http://www.secg.org/sec1-v2.pdf}SEC1}, section 2.3.4, that is to say:
 
     - the point at infinity is the single byte "00".
     - for a point (x, y) not at infinity, the format is:
       - the byte "04"
       - x serialized in big endian format, padded to 32 bytes.
       - y serialized in big endian format, padded to 32 bytes.
-
-    @see <http://www.secg.org/sec1-v2.pdf>
 *)
 
 val point_of_hex : Hex.t -> (point, point_error) result

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -1,3 +1,14 @@
+(** Diffie-Hellman key exchange over P-256 (secp256r1) curve.
+    This implementation uses C code from {{https://github.com/mit-plv/fiat-crypto}
+    Fiat-crypto project}.
+
+    @see <https://www.secg.org/SEC2-Ver-1.0.pdf> SEC2 : Recommended Elliptic
+    Curve Domain Parameters, section 2.7.2 - curve parameters
+    @see <https://tools.ietf.org/html/rfc8446#section-7.4.2> RFC8446, "The
+    Transport Layer Security (TLS) Protocol Version 1.3", section 7.4.2 - how to
+    use this in the context of TLS 1.3.
+*)
+
 (** A point on the P-256 curve (public key), that is not the point at infinity. *)
 type point
 

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -13,15 +13,16 @@ val pp_point_error : Format.formatter -> point_error -> unit
 (** Pretty printer for point parsing errors *)
 
 val point_of_cs : Cstruct.t -> (point, point_error) result
-(** Convert from cstruct. Refuses the point at infinity.
-    The format is the uncompressed format described in
-    {{http://www.secg.org/sec1-v2.pdf}SEC1}, section 2.3.4, that is to say:
+(** Convert from a cstruct encoding a point in the uncompressed format
+    described in {{http://www.secg.org/sec1-v2.pdf}SEC1}, section 2.3.4.
 
-    - the point at infinity is the single byte "00".
-    - for a point (x, y) not at infinity, the format is:
-      - the byte "04"
-      - x serialized in big endian format, padded to 32 bytes.
-      - y serialized in big endian format, padded to 32 bytes.
+    This performs the following checks:
+    - The header is either `00` or `04`, otherwise returns [Error `Invalid_format].
+    - The point is not at infinity (header `OO`), otherwise returns [Error `At_infinity].
+    - The point coordinate are 32 bytes long, otherwise returns [Error `Invalid_length].
+    - The point coordinates are within 0 and p-1, where p is the curve field order,
+      otherwise returns [Error `Invalid_range].
+    - The point is on the curve, otherwise returns [Error `Not_on_curve].
 *)
 
 val point_of_hex : Hex.t -> (point, point_error) result
@@ -42,9 +43,12 @@ val pp_scalar_error : Format.formatter -> scalar_error -> unit
 (** Pretty printer for scalar parsing errors *)
 
 val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
-(** Read data from a cstruct.
-    It should be 32 bytes long, in big endian format. Returns an error when the
-    number is zero, or if it is larger than or equal to the group order. *)
+(** Converts from a 32 bytes big endian cstruct.
+
+    This performs the following checks:
+    - The scalar is 32 bytes long, otherwise returns [Error `Invalid_length].
+    - The scalar is within 1 and n-1, where n is the curve group order, otherwise
+      returns [Error `Invalid_range]. *)
 
 val scalar_of_hex : Hex.t -> (scalar, scalar_error) result
 (** Like [scalar_of_cs] but read from hex data. *)
@@ -54,6 +58,5 @@ val dh : scalar:scalar -> point:point -> Cstruct.t
     scalar multiplication of [point] and [scalar]. *)
 
 val public : scalar -> point
-(** Compute the public key corresponding to a given private key. Internally,
-    this multiplies the generator by the scalar.
+(** Compute the p256 public key corresponding to a given private key.
     Given the invariant on [scalar], the result can't be the point at infinity. *)

--- a/p256/parameters.mli
+++ b/p256/parameters.mli
@@ -1,4 +1,4 @@
-(** Curve parameters.
+(** Curve parameters as defined in {{https://www.secg.org/SEC2-Ver-1.0.pdf}SEC2}.
     They are stored as [Hex.t] because [Fe.t] and [Cstruct.t] are
     mutable. *)
 


### PR DESCRIPTION
This addresses the issues mentioned in #32 :
- Adds a short intro.
- Add a link to the curve specification in `parameters.mli`.
- Add more precise specification of the performed checks in `of_cstruct`. 
- Remove useless precisions of implementation in `public`.

/cc @hannesm @NathanReb 