### PR TITLE
Comparisons are done in variable time and it is OK

### DIFF
--- a/p256/cstruct_util.ml
+++ b/p256/cstruct_util.ml
@@ -5,7 +5,7 @@ let pp_hex_le fmt cs =
     Format.fprintf fmt "%02x" byte
   done
 
-let compare_be a b =
+let compare_be_variable_time a b =
   let first_diff = ref None in
   let a_len = Cstruct.len a in
   let b_len = Cstruct.len b in
@@ -25,8 +25,8 @@ let compare_be a b =
   | Some d ->
       d
 
-let%expect_test "compare_be" =
-  let test a b = print_int (compare_be a b) in
+let%expect_test "compare_be_variable_time" =
+  let test a b = print_int (compare_be_variable_time a b) in
   test (Cstruct.of_string "aa") (Cstruct.of_string "ab");
   [%expect {| -1 |}];
   test (Cstruct.of_string "ab") (Cstruct.of_string "aa");

--- a/p256/cstruct_util.mli
+++ b/p256/cstruct_util.mli
@@ -2,6 +2,11 @@ val pp_hex_le : Format.formatter -> Cstruct.t -> unit
 (** Display the contents of a cstruct as hex data, seen as a little endian
     number. *)
 
-val compare_be : Cstruct.t -> Cstruct.t -> int
+val compare_be_variable_time : Cstruct.t -> Cstruct.t -> int
 (** Compare two cstructs, interpreting them as big endian numbers.
+
+    This function will take a different time depending on when the difference
+    appears. This is not a security concern when either of the operands is
+    public, in particular for range checks.
+
     Raises [Invalid_argument _] if they have a different length. *)

--- a/p256/point.ml
+++ b/p256/point.ml
@@ -29,7 +29,7 @@ let is_solution_to_curve_equation ~x ~y =
 
 let check_coordinate cs =
   let p = Hex.to_cstruct Parameters.p in
-  if Cstruct_util.compare_be cs p >= 0 then None
+  if Cstruct_util.compare_be_variable_time cs p >= 0 then None
   else Some (Fe.from_be_cstruct cs)
 
 (** Convert cstruct coordinates to a finite point ensuring:

--- a/p256/scalar.ml
+++ b/p256/scalar.ml
@@ -5,7 +5,8 @@ let pp fmt (Scalar s) = Cstruct_util.pp_hex_le fmt s
 let is_in_range cs =
   let zero = Cstruct.create 32 in
   let n = Hex.to_cstruct Parameters.n in
-  Cstruct_util.compare_be cs zero > 0 && Cstruct_util.compare_be n cs > 0
+  Cstruct_util.compare_be_variable_time cs zero > 0
+  && Cstruct_util.compare_be_variable_time n cs > 0
 
 let of_cstruct cs =
   if Cstruct.len cs <> 32 then Error `Invalid_length


### PR DESCRIPTION
Clarify that `compare_be` is not constant time by renaming it.

This is acceptable for range checks, since a timing oracle would only reveal the value an input is being compared to. In the existing uses, these are known constants corresponding to curve parameters.