### PR TITLE
Simplify API

### DIFF
--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -68,7 +68,7 @@ module Dhe = struct
     | Error _ ->
         generate_private_key ~rng ()
 
-  let generate_key ~rng =
+  let gen_key ~rng =
     let private_key = generate_private_key ~rng () in
     let public_key = public private_key in
     let to_send = point_to_cs public_key in

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -65,23 +65,25 @@ let scalar_of_hex = Scalar.of_hex
 
 let scalar_of_cs = Scalar.of_cstruct
 
-let rec generate_private_key ~rng () =
-  let candidate = rng 4 in
-  match scalar_of_cs candidate with
-  | Ok scalar ->
-      scalar
-  | Error _ ->
-      generate_private_key ~rng ()
+module Dhe = struct
+  let rec generate_private_key ~rng () =
+    let candidate = rng 4 in
+    match scalar_of_cs candidate with
+    | Ok scalar ->
+        scalar
+    | Error _ ->
+        generate_private_key ~rng ()
 
-let generate_key ~rng =
-  let private_key = generate_private_key ~rng () in
-  let public_key = public private_key in
-  let to_send = point_to_cs public_key in
-  (private_key, to_send)
+  let generate_key ~rng =
+    let private_key = generate_private_key ~rng () in
+    let public_key = public private_key in
+    let to_send = point_to_cs public_key in
+    (private_key, to_send)
 
-let key_exchange ~private_key received =
-  match point_of_cs received with
-  | Error _ as err ->
-      err
-  | Ok other_party_public_key ->
-      Ok (dh ~scalar:private_key ~point:other_party_public_key)
+  let key_exchange ~private_key received =
+    match point_of_cs received with
+    | Error _ as err ->
+        err
+    | Ok other_party_public_key ->
+        Ok (dh ~scalar:private_key ~point:other_party_public_key)
+end

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -64,3 +64,24 @@ let pp_scalar_error = Error.pp_scalar_error
 let scalar_of_hex = Scalar.of_hex
 
 let scalar_of_cs = Scalar.of_cstruct
+
+let rec generate_private_key ~rng () =
+  let candidate = rng 4 in
+  match scalar_of_cs candidate with
+  | Ok scalar ->
+      scalar
+  | Error _ ->
+      generate_private_key ~rng ()
+
+let generate_key ~rng =
+  let private_key = generate_private_key ~rng () in
+  let public_key = public private_key in
+  let to_send = point_to_cs public_key in
+  (private_key, to_send)
+
+let key_exchange ~private_key received =
+  match point_of_cs received with
+  | Error _ as err ->
+      err
+  | Ok other_party_public_key ->
+      Ok (dh ~scalar:private_key ~point:other_party_public_key)

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -34,8 +34,6 @@ let%expect_test "dh" =
   [%expect
     {| a7666bcc3818472194460f7df22d80a5886da0e1679eac930175ce1ff733c7ca |}]
 
-type point = Point.t
-
 type point_error = Error.point_error
 
 let pp_point_error = Error.pp_point_error
@@ -49,8 +47,6 @@ let check_point = function
   | Error _ as e ->
       e
 
-let point_of_hex h = check_point (Point.of_hex h)
-
 let point_of_cs c = check_point (Point.of_cstruct c)
 
 let point_to_cs = Point.to_cstruct
@@ -60,8 +56,6 @@ type scalar = Scalar.t
 type scalar_error = Error.scalar_error
 
 let pp_scalar_error = Error.pp_scalar_error
-
-let scalar_of_hex = Scalar.of_hex
 
 let scalar_of_cs = Scalar.of_cstruct
 

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -51,20 +51,20 @@ let point_of_cs c = check_point (Point.of_cstruct c)
 
 let point_to_cs = Point.to_cstruct
 
-type scalar = Scalar.t
+type secret = Scalar.t
 
-type scalar_error = Error.scalar_error
+type secret_error = Error.scalar_error
 
-let pp_scalar_error = Error.pp_scalar_error
+let pp_secret_error = Error.pp_scalar_error
 
-let scalar_of_cs = Scalar.of_cstruct
+let secret_of_cs = Scalar.of_cstruct
 
 module Dhe = struct
   let rec generate_private_key ~rng () =
     let candidate = rng 4 in
-    match scalar_of_cs candidate with
-    | Ok scalar ->
-        scalar
+    match secret_of_cs candidate with
+    | Ok secret ->
+        secret
     | Error _ ->
         generate_private_key ~rng ()
 
@@ -74,10 +74,10 @@ module Dhe = struct
     let to_send = point_to_cs public_key in
     (private_key, to_send)
 
-  let key_exchange ~private_key received =
+  let key_exchange secret received =
     match point_of_cs received with
     | Error _ as err ->
         err
     | Ok other_party_public_key ->
-        Ok (dh ~scalar:private_key ~point:other_party_public_key)
+        Ok (dh ~scalar:secret ~point:other_party_public_key)
 end

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -49,8 +49,7 @@ let check_point = function
   | Error _ as e ->
       e
 
-let point_of_hex h =
-  check_point (Point.of_hex h)
+let point_of_hex h = check_point (Point.of_hex h)
 
 let point_of_cs c = check_point (Point.of_cstruct c)
 

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -34,9 +34,9 @@ let%expect_test "dh" =
   [%expect
     {| a7666bcc3818472194460f7df22d80a5886da0e1679eac930175ce1ff733c7ca |}]
 
-type point_error = Error.point_error
+type error = Error.point_error
 
-let pp_point_error = Error.pp_point_error
+let pp_error = Error.pp_point_error
 
 let check_point = function
   | Ok p

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -53,10 +53,6 @@ let point_to_cs = Point.to_cstruct
 
 type secret = Scalar.t
 
-type secret_error = Error.scalar_error
-
-let pp_secret_error = Error.pp_scalar_error
-
 let secret_of_cs = Scalar.of_cstruct
 
 let rec generate_private_key ~rng () =

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -59,25 +59,23 @@ let pp_secret_error = Error.pp_scalar_error
 
 let secret_of_cs = Scalar.of_cstruct
 
-module Dhe = struct
-  let rec generate_private_key ~rng () =
-    let candidate = rng 4 in
-    match secret_of_cs candidate with
-    | Ok secret ->
-        secret
-    | Error _ ->
-        generate_private_key ~rng ()
+let rec generate_private_key ~rng () =
+  let candidate = rng 4 in
+  match secret_of_cs candidate with
+  | Ok secret ->
+      secret
+  | Error _ ->
+      generate_private_key ~rng ()
 
-  let gen_key ~rng =
-    let private_key = generate_private_key ~rng () in
-    let public_key = public private_key in
-    let to_send = point_to_cs public_key in
-    (private_key, to_send)
+let gen_key ~rng =
+  let private_key = generate_private_key ~rng () in
+  let public_key = public private_key in
+  let to_send = point_to_cs public_key in
+  (private_key, to_send)
 
-  let key_exchange secret received =
-    match point_of_cs received with
-    | Error _ as err ->
-        err
-    | Ok other_party_public_key ->
-        Ok (dh ~scalar:secret ~point:other_party_public_key)
-end
+let key_exchange secret received =
+  match point_of_cs received with
+  | Error _ as err ->
+      err
+  | Ok other_party_public_key ->
+      Ok (dh ~scalar:secret ~point:other_party_public_key)

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -64,6 +64,8 @@ let rec generate_private_key ~rng () =
   match secret_of_cs candidate with
   | Ok secret ->
       secret
+  | Error `Invalid_length ->
+      failwith "Fiat_p256.gen_key: generator returned an invalid length"
   | Error _ ->
       generate_private_key ~rng ()
 

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -12,21 +12,19 @@ val pp_error : Format.formatter -> error -> unit
 (** A scalar value. *)
 type secret
 
-module Dhe : sig
-  val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
-  (** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
-      The returned key pair MUST only be used for a single key exchange.
-      [rng] is the function used to repeteadly generate a private key until a valid candidate
-      is obtained. [rng]'s int parameter is the size of the [Cstruct.t] to generate.
-      The generated private key is checked to be greater than zero and lower than the group
-      order meaning the public key cannot be the point at inifinity. *)
+val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
+(** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
+    The returned key pair MUST only be used for a single key exchange.
+    [rng] is the function used to repeteadly generate a private key until a valid candidate
+    is obtained. [rng]'s int parameter is the size of the [Cstruct.t] to generate.
+    The generated private key is checked to be greater than zero and lower than the group
+    order meaning the public key cannot be the point at inifinity. *)
 
-  val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
-  (** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
-      using your private key and the other party's public key. Returns the shared secret
-      or an error if the received public is invalid or is the point at infinity.
-      @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)
-end
+val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
+(** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
+    using your private key and the other party's public key. Returns the shared secret
+    or an error if the received public is invalid or is the point at infinity.
+    @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)
 
 (**/**)
 

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -24,8 +24,11 @@ val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
     order meaning the public key cannot be the point at inifinity. *)
 
 val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
-(** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
-    using your private key and the other party's public key. Returns the shared secret
-    or an error if the received public is invalid or is the point at infinity.
+(** [key_exchange secret received_public_key] performs Diffie-Hellman key exchange
+    using your secret and the data received from the other party. Returns the shared secret
+    or an error if the received data is wrongly encoded, doesn't represent a point on the curve
+    or represent the point at infinity.
+
+    The shared secret is returned as is i.e. not stripped from leading 0x00 bytes.
 
     @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -29,22 +29,3 @@ val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
     or an error if the received public is invalid or is the point at infinity.
 
     @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)
-
-(**/**)
-
-(* Undocumented section *)
-
-(** The type for secret parsing errors. *)
-type secret_error =
-  [ `Invalid_length
-  | `Invalid_range ]
-
-val pp_secret_error : Format.formatter -> secret_error -> unit
-(** Pretty printer for secret parsing errors *)
-
-val secret_of_cs : Cstruct.t -> (secret, secret_error) result
-(** Read a secret from a cstruct.
-    It should be 32 bytes long, in big endian format. Returns an error when the
-    number is zero, or if it is larger than or equal to the group order. *)
-
-(**/**)

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -15,8 +15,11 @@ type secret
 val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
 (** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman
     over P256. The returned key pair MUST only be used for a single key exchange.
+
     [rng] is the function used to repeteadly generate a private key until a valid candidate
     is obtained. [rng]'s int parameter is the size of the [Cstruct.t] to generate.
+    If [rng] returns an invalid length buffer, [Failure _] is raised.
+
     The generated private key is checked to be greater than zero and lower than the group
     order meaning the public key cannot be the point at inifinity. *)
 
@@ -24,6 +27,7 @@ val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
 (** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
     using your private key and the other party's public key. Returns the shared secret
     or an error if the received public is invalid or is the point at infinity.
+
     @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)
 
 (**/**)

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -10,23 +10,10 @@ val pp_point_error : Format.formatter -> point_error -> unit
 (** Pretty printer for point parsing errors *)
 
 (** A scalar value. *)
-type scalar
-
-(** The type for scalar parsing errors. *)
-type scalar_error =
-  [ `Invalid_length
-  | `Invalid_range ]
-
-val pp_scalar_error : Format.formatter -> scalar_error -> unit
-(** Pretty printer for scalar parsing errors *)
-
-val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
-(** Read data from a cstruct.
-    It should be 32 bytes long, in big endian format. Returns an error when the
-    number is zero, or if it is larger than or equal to the group order. *)
+type secret
 
 module Dhe : sig
-  val gen_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
+  val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
   (** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
       The returned key pair MUST only be used for a single key exchange.
       [rng] is the function used to repeteadly generate a private key until a valid candidate
@@ -34,10 +21,28 @@ module Dhe : sig
       The generated private key is checked to be greater than zero and lower than the group
       order meaning the public key cannot be the point at inifinity. *)
 
-  val key_exchange :
-    private_key:scalar -> Cstruct.t -> (Cstruct.t, point_error) result
+  val key_exchange : secret -> Cstruct.t -> (Cstruct.t, point_error) result
   (** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
       using your private key and the other party's public key. Returns the shared secret
       or an error if the received public is invalid or is the point at infinity.
       @see <http://www.secg.org/sec1-v2.pdf> for public key encoding format. *)
 end
+
+(**/**)
+
+(* Undocumented section *)
+
+(** The type for secret parsing errors. *)
+type secret_error =
+  [ `Invalid_length
+  | `Invalid_range ]
+
+val pp_secret_error : Format.formatter -> secret_error -> unit
+(** Pretty printer for secret parsing errors *)
+
+val secret_of_cs : Cstruct.t -> (secret, secret_error) result
+(** Read a secret from a cstruct.
+    It should be 32 bytes long, in big endian format. Returns an error when the
+    number is zero, or if it is larger than or equal to the group order. *)
+
+(**/**)

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -9,12 +9,12 @@ type error =
 val pp_error : Format.formatter -> error -> unit
 (** Pretty printer for public key parsing errors *)
 
-(** A scalar value. *)
+(** Type for P256 private keys *)
 type secret
 
 val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
-(** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
-    The returned key pair MUST only be used for a single key exchange.
+(** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman
+    over P256. The returned key pair MUST only be used for a single key exchange.
     [rng] is the function used to repeteadly generate a private key until a valid candidate
     is obtained. [rng]'s int parameter is the size of the [Cstruct.t] to generate.
     The generated private key is checked to be greater than zero and lower than the group

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -26,11 +26,11 @@ val scalar_of_cs : Cstruct.t -> (scalar, scalar_error) result
     number is zero, or if it is larger than or equal to the group order. *)
 
 module Dhe : sig
-  val generate_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
-  (** [generate_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
+  val gen_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
+  (** [gen_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
       The returned key pair MUST only be used for a single key exchange.
       [rng] is the function used to repeteadly generate a private key until a valid candidate
-      is obtained. [rng]'s int parameter is the size of [Cstruct.t] to generate.
+      is obtained. [rng]'s int parameter is the size of the [Cstruct.t] to generate.
       The generated private key is checked to be greater than zero and lower than the group
       order meaning the public key cannot be the point at inifinity. *)
 

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -60,7 +60,18 @@ val public : scalar -> point
     this multiplies the generator by the scalar.
     Given the invariant on [scalar], the result can't be the point at infinity. *)
 
-val generate_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
+module Dhe : sig
+  val generate_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
+  (** [generate_key ~rng] generates a private and a public key for Ephemeral Diffie-Hellman.
+      The returned key pair MUST only be used for a single key exchange.
+      [rng] is the function used to repeteadly generate a private key until a valid candidate
+      is obtained. [rng]'s int parameter is the size of [Cstruct.t] to generate.
+      The generated private key is checked to be greater than zero and lower than the group
+      order meaning the public key cannot be the point at inifinity. *)
 
-val key_exchange :
-  private_key:scalar -> Cstruct.t -> (Cstruct.t, point_error) result
+  val key_exchange :
+    private_key:scalar -> Cstruct.t -> (Cstruct.t, point_error) result
+  (** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
+      using your private key and the other party's public key. Returns the shared secret
+      or an error if the received public is invalid or is the point at infinity. *)
+end

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -1,13 +1,13 @@
-(** The type for point parsing errors. *)
-type point_error =
+(** The type for public key parsing errors. *)
+type error =
   [ `Invalid_range
   | `Invalid_format
   | `Invalid_length
   | `Not_on_curve
   | `At_infinity ]
 
-val pp_point_error : Format.formatter -> point_error -> unit
-(** Pretty printer for point parsing errors *)
+val pp_error : Format.formatter -> error -> unit
+(** Pretty printer for public key parsing errors *)
 
 (** A scalar value. *)
 type secret
@@ -21,7 +21,7 @@ module Dhe : sig
       The generated private key is checked to be greater than zero and lower than the group
       order meaning the public key cannot be the point at inifinity. *)
 
-  val key_exchange : secret -> Cstruct.t -> (Cstruct.t, point_error) result
+  val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
   (** [key_exchange ~private_key received_public_key] performs Diffie-Hellman key exchange
       using your private key and the other party's public key. Returns the shared secret
       or an error if the received public is invalid or is the point at infinity.

--- a/p256/fiat_p256.mli
+++ b/p256/fiat_p256.mli
@@ -59,3 +59,8 @@ val public : scalar -> point
 (** Compute the public key corresponding to a given private key. Internally,
     this multiplies the generator by the scalar.
     Given the invariant on [scalar], the result can't be the point at infinity. *)
+
+val generate_key : rng:(int -> Cstruct.t) -> scalar * Cstruct.t
+
+val key_exchange :
+  private_key:scalar -> Cstruct.t -> (Cstruct.t, point_error) result

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -16,7 +16,8 @@ val double : t -> t
 val of_cstruct :
      Cstruct.t
   -> ( t
-     , [> `Invalid_format | `Invalid_length | `Invalid_range | `Not_on_curve] )
+     , [> `Invalid_format | `Invalid_length | `Invalid_range | `Not_on_curve]
+     )
      result
 (** Convert from cstruct. The format is the uncompressed format described in
     SEC1, section 2.3.4, that is to say:
@@ -33,7 +34,8 @@ val of_cstruct :
 val of_hex :
      Hex.t
   -> ( t
-     , [> `Invalid_format | `Invalid_length | `Invalid_range | `Not_on_curve] )
+     , [> `Invalid_format | `Invalid_length | `Invalid_range | `Not_on_curve]
+     )
      result
 (** Convert from hex. See [of_cstruct]. *)
 

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -74,7 +74,7 @@ let perform_key_exchange ~public_key ~raw_private_key =
   to_string_result ~pp_error:pp_scalar_error (scalar_of_cs raw_private_key)
   >>= fun private_key ->
   to_string_result ~pp_error:pp_point_error
-    (key_exchange ~private_key public_key)
+    (Dhe.key_exchange ~private_key public_key)
 
 let interpret_test ~tcId {public_key; raw_private_key; expected} () =
   match perform_key_exchange ~public_key ~raw_private_key with

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -73,8 +73,7 @@ let perform_key_exchange ~public_key ~raw_private_key =
   let open Fiat_p256 in
   to_string_result ~pp_error:pp_secret_error (secret_of_cs raw_private_key)
   >>= fun secret ->
-  to_string_result ~pp_error:pp_point_error
-    (Dhe.key_exchange secret public_key)
+  to_string_result ~pp_error (Dhe.key_exchange secret public_key)
 
 let interpret_test ~tcId {public_key; raw_private_key; expected} () =
   match perform_key_exchange ~public_key ~raw_private_key with

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -71,8 +71,8 @@ type test =
 
 let perform_key_exchange ~public_key ~raw_private_key =
   let open Fiat_p256 in
-  to_string_result ~pp_error:pp_secret_error (secret_of_cs raw_private_key)
-  >>= fun secret ->
+  let gen _ = raw_private_key in
+  let secret, _ = gen_key ~rng:gen in
   to_string_result ~pp_error (key_exchange secret public_key)
 
 let interpret_test ~tcId {public_key; raw_private_key; expected} () =

--- a/test_wycheproof/test.ml
+++ b/test_wycheproof/test.ml
@@ -73,7 +73,7 @@ let perform_key_exchange ~public_key ~raw_private_key =
   let open Fiat_p256 in
   to_string_result ~pp_error:pp_secret_error (secret_of_cs raw_private_key)
   >>= fun secret ->
-  to_string_result ~pp_error (Dhe.key_exchange secret public_key)
+  to_string_result ~pp_error (key_exchange secret public_key)
 
 let interpret_test ~tcId {public_key; raw_private_key; expected} () =
   match perform_key_exchange ~public_key ~raw_private_key with


### PR DESCRIPTION
This PR simplifies the fiat API. This is a follow up to some feedback from @hannesm.

I extracted `generate_key` and `key_echange` functions to a `Dhe` submodule.

We could simplify it further by renaming some of the types ie `point` -> `public_key` and `scalar` -> `private_key` but that's out of the scope of this PR.