### PR TITLE
Use bigarray-compat

### DIFF
--- a/fiat-p256.opam
+++ b/fiat-p256.opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "alcotest" {with-test}
   "asn1-combinators" {with-test}
-  "cstruct" {>= "3.5.0"}
+  "cstruct" {>= "3.5.0" & < "5.0.0"}
   "dune" {build & >= "1.6.0"}
   "hex"
   "hex" {with-test}

--- a/fiat-p256.opam
+++ b/fiat-p256.opam
@@ -17,7 +17,8 @@ build: [
 depends: [
   "alcotest" {with-test}
   "asn1-combinators" {with-test}
-  "cstruct" {>= "3.5.0" & < "5.0.0"}
+  "bigarray-compat"
+  "cstruct" {>= "3.5.0"}
   "dune" {build & >= "1.6.0"}
   "hex"
   "hex" {with-test}

--- a/p256/dune
+++ b/p256/dune
@@ -1,7 +1,7 @@
 (library
  (name fiat_p256)
  (public_name fiat-p256)
- (libraries cstruct hex)
+ (libraries bigarray-compat cstruct hex)
  (c_names p256_stubs)
  (c_flags (:include discover/cflags.sexp))
  (preprocess (pps ppx_expect))

--- a/p256/fe.ml
+++ b/p256/fe.ml
@@ -15,7 +15,7 @@ let r_squared =
 
 let to_montgomery x = mul x x r_squared
 
-let copy dst src = Bigarray.Array1.blit src dst
+let copy dst src = Bigarray_compat.Array1.blit src dst
 
 external from_bytes_buf :
   t -> Cstruct.buffer -> unit


### PR DESCRIPTION
Cstruct 5.0.0 dropped its dependency over `bigarray` in favor of
`bigarray-compat` transitively breaking `fiat`. This could be fixed
by also using `bigarray-compat` instead of `bigarray`, which would be
the right thing to do, but because `asn1-combinators` also transitively
depends on `bigarray` we'd still end up breaking any binary built using
fiat.

This is a temporary solution so I'll open an issue as a remainder that
we need to upgrade once `asn1-combinators` does.