### PR TITLE
Fix generate_key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## unreleased
 
+### Fixed
+
+- Fix a bug in `generate_key` where it would never actually work when used with
+  a proper `rng` function (#44, @NathanReb)
+
 ## v0.1.0
 
 *2019-06-28*

--- a/fiat-p256.opam
+++ b/fiat-p256.opam
@@ -27,6 +27,7 @@ depends: [
   "hex"
   "hex" {with-test}
   "ppx_deriving_yojson" {with-test}
+  "rresult" {with-test}
   "ppx_expect"
   "yojson" {with-test & >= "1.6.0"}
 ]

--- a/p256/fiat_p256.ml
+++ b/p256/fiat_p256.ml
@@ -56,7 +56,7 @@ type secret = Scalar.t
 let secret_of_cs = Scalar.of_cstruct
 
 let rec generate_private_key ~rng () =
-  let candidate = rng 4 in
+  let candidate = rng 32 in
   match secret_of_cs candidate with
   | Ok secret ->
       secret

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_fiat_p256)
+ (libraries alcotest fiat-p256 rresult))

--- a/test/test_fiat_p256.ml
+++ b/test/test_fiat_p256.ml
@@ -1,0 +1,41 @@
+module Testable = struct
+  let cstruct =
+    let pp fmt t = Hex.pp fmt (Hex.of_cstruct t) in
+    Alcotest.testable pp Cstruct.equal
+end
+
+let list_init l f =
+  let rec go acc i =
+    if i = l then
+      List.rev acc
+    else
+      go ((f i)::acc) (i + 1)
+  in
+  go [] 0
+
+let int32_to_hex i = Printf.sprintf "%08Lx" i
+
+let prng len =
+  let i32_count = len / 4 + 1 in
+  let i32s = list_init i32_count (fun _ -> Random.int64 0x100000000L) in
+  let as_hex = String.concat "" (List.map int32_to_hex i32s) in
+  Cstruct.of_hex (String.sub as_hex 0 (len * 2))
+
+let whole_key_exchange =
+  let open Rresult.R.Infix in
+  let test_name = "whole_key_exchange" in
+  let test_fun () =
+    let res =
+      let secret1, public1 = Fiat_p256.gen_key ~rng:prng in
+      let secret2, public2 = Fiat_p256.gen_key ~rng:prng in
+      Fiat_p256.key_exchange secret1 public2 >>= fun shared1 ->
+      Fiat_p256.key_exchange secret2 public1 >>= fun shared2 ->
+      Ok (shared1, shared2)
+    in
+    match res with
+    | Ok (s1, s2) -> Alcotest.check Testable.cstruct test_name s1 s2
+    | Error e -> Alcotest.failf "Key exchange failed with error %a" Fiat_p256.pp_error e
+  in
+  [(test_name, `Quick, test_fun)]
+
+let () = Alcotest.run "Fiat_p256" [("Functional", whole_key_exchange)]

--- a/test/test_fiat_p256.ml
+++ b/test/test_fiat_p256.ml
@@ -38,4 +38,6 @@ let whole_key_exchange =
   in
   [(test_name, `Quick, test_fun)]
 
-let () = Alcotest.run "Fiat_p256" [("Functional", whole_key_exchange)]
+let () =
+  Random.self_init ();
+  Alcotest.run "Fiat_p256" [("Functional", whole_key_exchange)]


### PR DESCRIPTION
We should add basic tests that just performs a full key exchange to catch that kind of stupid/horrible mistake.