### PR TITLE
Use constant-time selection in scalar mult

### DIFF
--- a/p256/field_element.ml
+++ b/p256/field_element.ml
@@ -56,3 +56,10 @@ let from_be_cstruct cs =
   from_bytes fe cs_rev;
   to_montgomery fe;
   fe
+
+external select_c : t -> bool -> t -> t -> unit = "fiat_p256_caml_select"
+
+let select bit ~then_ ~else_ =
+  let out = create () in
+  select_c out bit then_ else_;
+  out

--- a/p256/field_element.mli
+++ b/p256/field_element.mli
@@ -56,3 +56,8 @@ val inv : t -> t -> unit
 
 val from_be_cstruct : Cstruct.t -> t
 (** Converts from a big-endian cstruct to Montgomery form. *)
+
+val select : bool -> then_:t -> else_:t -> t
+(** Constant-time selection.
+    [select true ~then_ ~false_] returns a copy of [then_], and
+    [select false ~then_ ~false_] returns a copy of [else_]. *)

--- a/p256/p256_stubs.c
+++ b/p256/p256_stubs.c
@@ -385,3 +385,15 @@ CAMLprim value fiat_p256_caml_point_add(value out, value p, value q)
 	);
 	CAMLreturn(Val_unit);
 }
+
+CAMLprim value fiat_p256_caml_select(value out, value bit, value t, value f)
+{
+	CAMLparam4(out, bit, t, f);
+	fe_cmovznz(
+		Caml_ba_data_val(out),
+		Bool_val(bit),
+		Caml_ba_data_val(f),
+		Caml_ba_data_val(t)
+	);
+	CAMLreturn(Val_unit);
+}

--- a/p256/point.ml
+++ b/p256/point.ml
@@ -110,3 +110,10 @@ let params_g =
   let x = Hex.to_cstruct Parameters.g_x in
   let y = Hex.to_cstruct Parameters.g_y in
   match validate_finite_point ~x ~y with Ok p -> p | Error _ -> assert false
+
+let select bit ~then_ ~else_ =
+  {
+    f_x = Fe.select bit ~then_:then_.f_x ~else_:else_.f_x;
+    f_y = Fe.select bit ~then_:then_.f_y ~else_:else_.f_y;
+    f_z = Fe.select bit ~then_:then_.f_z ~else_:else_.f_z;
+  }

--- a/p256/point.mli
+++ b/p256/point.mli
@@ -38,3 +38,6 @@ val x_of_finite_point : t -> Cstruct.t
 
 val params_g : t
 (** The curve's base point *)
+
+val select : bool -> then_:t -> else_:t -> t
+(** Constant-time selection. See [Field_element.select]. *)

--- a/p256/scalar_mult.ml
+++ b/p256/scalar_mult.ml
@@ -2,11 +2,11 @@ let scalar_mult d p =
   let r0 = ref (Point.at_infinity ()) in
   let r1 = ref p in
   for i = 255 downto 0 do
-    if Scalar.bit_at d i then (
-      r0 := Point.add !r0 !r1;
-      r1 := Point.double !r1 )
-    else (
-      r1 := Point.add !r0 !r1;
-      r0 := Point.double !r0 )
+    let bit = Scalar.bit_at d i in
+    let sum = Point.add !r0 !r1 in
+    let r0_double = Point.double !r0 in
+    let r1_double = Point.double !r1 in
+    r0 := Point.select bit ~then_:sum ~else_:r0_double;
+    r1 := Point.select bit ~then_:r1_double ~else_:sum
   done;
   !r0


### PR DESCRIPTION
Closes #47

This eliminates key-dependent branching by using constant-time selection.

The idea is to replace:

    if b then
      r := t
    else
      r := f

by:

    r := b * t + (1 - b) * f

The math part is done by `fe_cmovznz`, which is already present in the C stubs.